### PR TITLE
added assetName. marked plugin readonly. added ordering.

### DIFF
--- a/python/foglamp/plugins/south/sinusoid/sinusoid.py
+++ b/python/foglamp/plugins/south/sinusoid/sinusoid.py
@@ -25,14 +25,22 @@ __version__ = "${VERSION}"
 
 _DEFAULT_CONFIG = {
     'plugin': {
-        'description': 'Sinusoid async plugin',
+        'description': 'Sinusoid Plugin',
         'type': 'string',
-        'default': 'sinusoid'
+        'default': 'sinusoid',
+        'readonly': 'true'
+    },
+    'assetName': {
+        'description': 'Name of Asset',
+        'type': 'string',
+        'default': 'sinusoid',
+        'order': '1'
     },
     'dataPointsPerSec': {
         'description': 'Data points per second',
         'type': 'integer',
-        'default': "1"
+        'default': '1',
+        'order': '2'
     }
 }
 
@@ -161,7 +169,7 @@ def plugin_start(handle):
                 # https://github.com/foglamp/FogLAMP/commit/66dead988152cd3724eba6b4288b630cfa6a2e30
                 time_stamp = str(datetime.datetime.now(datetime.timezone.utc).astimezone())  # utils.local_timestamp()
                 data = {
-                    'asset': 'sinusoid',
+                    'asset': handle['assetName']['value'],
                     'timestamp': time_stamp,
                     'key': str(uuid.uuid4()),
                     'readings': {
@@ -173,7 +181,7 @@ def plugin_start(handle):
                                           timestamp=data['timestamp'], key=data['key'],
                                           readings=data['readings'])
 
-                await asyncio.sleep(1/(int(handle['dataPointsPerSec']['value'])))
+                await asyncio.sleep(1 / (int(handle['dataPointsPerSec']['value'])))
 
         except asyncio.CancelledError:
             pass

--- a/test/test_sinusoid.py
+++ b/test/test_sinusoid.py
@@ -16,6 +16,7 @@ __version__ = "${VERSION}"
 
 config = sinusoid._DEFAULT_CONFIG
 
+
 def test_plugin_contract():
     # Evaluates if the plugin has all the required methods
     assert callable(getattr(sinusoid, 'plugin_info'))
@@ -50,15 +51,7 @@ def test_plugin_reconfigure():
     pass
 
 
-def test__plugin_stop():
-    with patch.object(sinusoid._LOGGER, 'info') as patch_logger_info:
-        sinusoid._plugin_stop(config)
-    patch_logger_info.assert_called_once_with('sinusoid disconnected.')
-
-
 def test_plugin_shutdown():
-    with patch.object(sinusoid, "_plugin_stop", return_value="") as patch_stop:
-        with patch.object(sinusoid._LOGGER, 'info') as patch_logger_info:
-            sinusoid.plugin_shutdown(config)
-        patch_logger_info.assert_called_once_with('sinusoid plugin shut down.')
-    patch_stop.assert_called_once_with(config)
+    with patch.object(sinusoid._LOGGER, 'info') as patch_logger_info:
+        sinusoid.plugin_shutdown(config)
+    patch_logger_info.assert_called_once_with('sinusoid plugin shut down.')


### PR DESCRIPTION
```
collected 6 items                                                                                                                             

test/test_sinusoid.py::test_plugin_contract PASSED
test/test_sinusoid.py::test_plugin_info PASSED
test/test_sinusoid.py::test_plugin_init PASSED
test/test_sinusoid.py::test_plugin_start SKIPPED
test/test_sinusoid.py::test_plugin_reconfigure SKIPPED
test/test_sinusoid.py::test_plugin_shutdown PASSED

== 4 passed, 2 skipped in 0.05 seconds =
```