### PR TITLE
Zerodivision error handling and flexibility to use float for datapoints per second

### DIFF
--- a/python/foglamp/plugins/south/sinusoid/sinusoid.py
+++ b/python/foglamp/plugins/south/sinusoid/sinusoid.py
@@ -184,9 +184,8 @@ def plugin_start(handle):
                 try:
                     await asyncio.sleep(1 / (float(handle['dataPointsPerSec']['value'])))
                 except ZeroDivisionError:
-                    _LOGGER.warning('Data points per second must be greater than 0, defaulting to {}'.format(1))
-                    handle['dataPointsPerSec']['value'] = '1'
-
+                    _LOGGER.warning('Data points per second must be greater than 0, defaulting to sleep time 1')
+                    await asyncio.sleep(1)
         except asyncio.CancelledError:
             pass
         except (Exception, RuntimeError) as ex:

--- a/python/foglamp/plugins/south/sinusoid/sinusoid.py
+++ b/python/foglamp/plugins/south/sinusoid/sinusoid.py
@@ -9,6 +9,7 @@
 import asyncio
 import copy
 import uuid
+import logging
 
 from foglamp.common import logger
 from foglamp.plugins.common import utils
@@ -43,7 +44,7 @@ _DEFAULT_CONFIG = {
     }
 }
 
-_LOGGER = logger.setup(__name__, level=20)
+_LOGGER = logger.setup(__name__, level=logging.INFO)
 index = -1
 _task = None
 
@@ -180,11 +181,14 @@ def plugin_start(handle):
                                           timestamp=data['timestamp'], key=data['key'],
                                           readings=data['readings'])
 
-                await asyncio.sleep(1 / (int(handle['dataPointsPerSec']['value'])))
+                try:
+                    await asyncio.sleep(1 / (float(handle['dataPointsPerSec']['value'])))
+                except ZeroDivisionError:
+                    _LOGGER.warning('Data points per second must be greater than 0, defaulting to {}'.format(1))
+                    handle['dataPointsPerSec']['value'] = '1'
 
         except asyncio.CancelledError:
             pass
-
         except (Exception, RuntimeError) as ex:
             _LOGGER.exception("Sinusoid exception: {}".format(str(ex)))
             raise exceptions.DataRetrievalError(ex)

--- a/python/foglamp/plugins/south/sinusoid/sinusoid.py
+++ b/python/foglamp/plugins/south/sinusoid/sinusoid.py
@@ -184,7 +184,8 @@ def plugin_start(handle):
                 try:
                     await asyncio.sleep(1 / (float(handle['dataPointsPerSec']['value'])))
                 except ZeroDivisionError:
-                    _LOGGER.warning('Data points per second must be greater than 0, defaulting to sleep time 1')
+                    _LOGGER.warning('Data points per second must be greater than 0, defaulting to 1')
+                    handle['dataPointsPerSec']['value'] = '1'
                     await asyncio.sleep(1)
         except asyncio.CancelledError:
             pass


### PR DESCRIPTION
`await asyncio.sleep(1 / (int(handle['dataPointsPerSec']['value'])))` this is as int
So converted to float will always be good and it will allow flexibility here to use float
i.e float(1) == 1.0


if we need to change the type of dataPointsPerSec, we shall be able to use float type Once merged https://github.com/foglamp/FogLAMP/pull/1116