### PR TITLE
FOGL-2270 sinusoid poll mode

### DIFF
--- a/VERSION.south.sinusoid
+++ b/VERSION.south.sinusoid
@@ -1,2 +1,2 @@
 foglamp_south_sinusoid_version=2.0.0
-foglamp_version>=1.5
+foglamp_version>=1.4

--- a/VERSION.south.sinusoid
+++ b/VERSION.south.sinusoid
@@ -1,2 +1,2 @@
-foglamp_south_sinusoid_version=1.0.0
-foglamp_version>=1.3
+foglamp_south_sinusoid_version=2.0.0
+foglamp_version>=1.5

--- a/python/foglamp/plugins/south/sinusoid/sinusoid.py
+++ b/python/foglamp/plugins/south/sinusoid/sinusoid.py
@@ -120,7 +120,7 @@ def plugin_info():
     """
     return {
         'name': 'Sinusoid Poll plugin',
-        'version': '1.0',
+        'version': '2.0.0',
         'mode': 'poll',
         'type': 'south',
         'interface': '1.0',

--- a/python/foglamp/plugins/south/sinusoid/sinusoid.py
+++ b/python/foglamp/plugins/south/sinusoid/sinusoid.py
@@ -4,9 +4,8 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-""" Module for Sinusoid async plugin """
+""" Module for Sinusoid poll mode plugin """
 
-import asyncio
 import copy
 import uuid
 import logging
@@ -14,8 +13,6 @@ import logging
 from foglamp.common import logger
 from foglamp.plugins.common import utils
 from foglamp.services.south import exceptions
-from foglamp.services.south.ingest import Ingest
-
 
 __author__ = "Ashish Jabble"
 __copyright__ = "Copyright (c) 2018 Dianomic Systems"
@@ -25,7 +22,7 @@ __version__ = "${VERSION}"
 
 _DEFAULT_CONFIG = {
     'plugin': {
-        'description': 'Sinusoid Plugin',
+        'description': 'Sinusoid Poll Plugin which implements sine wave with data points',
         'type': 'string',
         'default': 'sinusoid',
         'readonly': 'true'
@@ -34,67 +31,13 @@ _DEFAULT_CONFIG = {
         'description': 'Name of Asset',
         'type': 'string',
         'default': 'sinusoid',
-        'order': '1',
         'displayName': 'Asset name'
-    },
-    'dataPointsPerSec': {
-        'description': 'Data points per second',
-        'type': 'integer',
-        'default': '1',
-        'order': '2',
-        'displayName': 'Data points per second'
     }
 }
 
 _LOGGER = logger.setup(__name__, level=logging.INFO)
 index = -1
-_task = None
-
-
-def plugin_info():
-    """ Returns information about the plugin.
-    Args:
-    Returns:
-        dict: plugin information
-    Raises:
-    """
-
-    return {
-        'name': 'Sinusoid plugin',
-        'version': '1.0',
-        'mode': 'async',
-        'type': 'south',
-        'interface': '1.0',
-        'config': _DEFAULT_CONFIG
-    }
-
-
-def plugin_init(config):
-    """ Initialise the plugin.
-    Args:
-        config: JSON configuration document for the South plugin configuration category
-    Returns:
-        data: JSON object to be used in future calls to the plugin
-    Raises:
-    """
-    data = copy.deepcopy(config)
-    return data
-
-
-def plugin_start(handle):
-    """ Extracts data from the sinusoid and returns it in a JSON document as a Python dict.
-    Available for async mode only.
-
-    Args:
-        handle: handle returned by the plugin initialisation call
-    Returns:
-        a sinusoid reading in a JSON document, as a Python dict, if it is available
-        None - If no reading is available
-    Raises:
-        TimeoutError
-    """
-    global _task
-    sine = [
+sine = [
         0.0,
         0.104528463,
         0.207911691,
@@ -157,45 +100,65 @@ def plugin_start(handle):
         -0.104528463
     ]
 
-    def generate_data():
-        global index
-        while index >= -1:
-            # index exceeds, reset to default
-            if index >= 59:
-                index = -1
-            index += 1
-            yield sine[index]
 
-    async def save_data():
-        try:
-            while True:
-                time_stamp = utils.local_timestamp()
-                data = {
-                    'asset': handle['assetName']['value'],
-                    'timestamp': time_stamp,
-                    'key': str(uuid.uuid4()),
-                    'readings': {
-                        "sinusoid": next(generate_data())
-                    }
-                }
+def generate_data():
+    global index
+    while index >= -1:
+        # index exceeds, reset to default
+        if index >= 59:
+            index = -1
+        index += 1
+        yield sine[index]
 
-                await Ingest.add_readings(asset='{}'.format(data['asset']),
-                                          timestamp=data['timestamp'], key=data['key'],
-                                          readings=data['readings'])
 
-                try:
-                    await asyncio.sleep(1 / (float(handle['dataPointsPerSec']['value'])))
-                except ZeroDivisionError:
-                    _LOGGER.warning('Data points per second must be greater than 0, defaulting to 1')
-                    handle['dataPointsPerSec']['value'] = '1'
-                    await asyncio.sleep(1)
-        except asyncio.CancelledError:
-            pass
-        except (Exception, RuntimeError) as ex:
-            _LOGGER.exception("Sinusoid exception: {}".format(str(ex)))
-            raise exceptions.DataRetrievalError(ex)
+def plugin_info():
+    """ Returns information about the plugin.
+    Args:
+    Returns:
+        dict: plugin information
+    Raises:
+    """
+    return {
+        'name': 'Sinusoid Poll plugin',
+        'version': '1.0',
+        'mode': 'poll',
+        'type': 'south',
+        'interface': '1.0',
+        'config': _DEFAULT_CONFIG
+    }
 
-    _task = asyncio.ensure_future(save_data())
+
+def plugin_init(config):
+    """ Initialise the plugin.
+    Args:
+        config: JSON configuration document for the South plugin configuration category
+    Returns:
+        data: JSON object to be used in future calls to the plugin
+    Raises:
+    """
+    data = copy.deepcopy(config)
+    return data
+
+
+def plugin_poll(handle):
+    """ Extracts data from the sensor and returns it in a JSON document as a Python dict.
+    Available for poll mode only.
+    Args:
+        handle: handle returned by the plugin initialisation call
+    Returns:
+        returns a sensor reading in a JSON document, as a Python dict, if it is available
+        None - If no reading is available
+    Raises:
+        TimeoutError
+    """
+    try:
+        time_stamp = utils.local_timestamp()
+        data = {'asset':  handle['assetName']['value'], 'timestamp': time_stamp, 'key': str(uuid.uuid4()), 'readings': {"sinusoid": next(generate_data())}}
+    except (Exception, RuntimeError) as ex:
+        _LOGGER.exception("Sinusoid exception: {}".format(str(ex)))
+        raise exceptions.DataRetrievalError(ex)
+    else:
+        return data
 
 
 def plugin_reconfigure(handle, new_config):
@@ -208,20 +171,7 @@ def plugin_reconfigure(handle, new_config):
         new_handle: new handle to be used in the future calls
     """
     _LOGGER.info("Old config for sinusoid plugin {} \n new config {}".format(handle, new_config))
-
-    # Find diff between old config and new config
-    diff = utils.get_diff(handle, new_config)
-
-    # Plugin should re-initialize and restart if key configuration is changed
-    if 'dataPointsPerSec' in diff or 'assetName' in diff:
-        plugin_shutdown(handle)
-        new_handle = plugin_init(new_config)
-        new_handle['restart'] = 'yes'
-        _LOGGER.info("Restarting Sinusoid plugin due to change in configuration key [{}]".format(', '.join(diff)))
-    else:
-        new_handle = copy.deepcopy(new_config)
-        new_handle['restart'] = 'no'
-
+    new_handle = copy.deepcopy(new_config)
     return new_handle
 
 
@@ -233,9 +183,4 @@ def plugin_shutdown(handle):
     Returns:
         plugin shutdown
     """
-    global _task
-    if _task is not None:
-        _task.cancel()
-        _task = None
-
     _LOGGER.info('sinusoid plugin shut down.')

--- a/test/test_sinusoid.py
+++ b/test/test_sinusoid.py
@@ -29,7 +29,7 @@ def test_plugin_contract():
 def test_plugin_info():
     assert sinusoid.plugin_info() == {
         'name': 'Sinusoid Poll plugin',
-        'version': '1.0',
+        'version': '2.0.0',
         'mode': 'poll',
         'type': 'south',
         'interface': '1.0',

--- a/test/test_sinusoid.py
+++ b/test/test_sinusoid.py
@@ -21,16 +21,16 @@ def test_plugin_contract():
     # Evaluates if the plugin has all the required methods
     assert callable(getattr(sinusoid, 'plugin_info'))
     assert callable(getattr(sinusoid, 'plugin_init'))
-    assert callable(getattr(sinusoid, 'plugin_start'))
+    assert callable(getattr(sinusoid, 'plugin_poll'))
     assert callable(getattr(sinusoid, 'plugin_shutdown'))
     assert callable(getattr(sinusoid, 'plugin_reconfigure'))
 
 
 def test_plugin_info():
     assert sinusoid.plugin_info() == {
-        'name': 'Sinusoid plugin',
+        'name': 'Sinusoid Poll plugin',
         'version': '1.0',
-        'mode': 'async',
+        'mode': 'poll',
         'type': 'south',
         'interface': '1.0',
         'config': config
@@ -42,7 +42,7 @@ def test_plugin_init():
 
 
 @pytest.mark.skip(reason="To be implemented")
-def test_plugin_start():
+def test_plugin_poll():
     pass
 
 


### PR DESCRIPTION
**Known_issues:**

1) **foglamp_version:**-> This plugin is compatible with foglamp **develop branch** only.
2)  _git tag_ but we can't at the moment due to FOGL-2236


**NOTE:** - 
1) Async version back up here https://github.com/foglamp/foglamp-south-sinusoid/tree/async_backup
2) **pollInterval** config item is no more use at plugin level as it is handled by southAdvanced Config and "**restart**" key is removed from reconfiguration as this key is used only by Python South server.