### PR TITLE
requires sed fixes in make_rpm script

### DIFF
--- a/make_rpm
+++ b/make_rpm
@@ -104,9 +104,8 @@ cp -R ${GIT_ROOT}/packages/RPM/* .
 sed -i "s/__VERSION__/${version}/g" SPECS/foglamp.spec
 sed -i "s/__NAME__/${pkg_name}/g" SPECS/foglamp.spec
 sed -i "s/__ARCH__/${arch}/g" SPECS/foglamp.spec
-sed -i "s/Requires: foglamp/Requires: foglamp (${foglamp_version})/g" SPECS/foglamp.spec
+sed -i "s/Requires:\([[:space:]]*\)foglamp/Requires:\1foglamp${foglamp_version}/g" SPECS/foglamp.spec
 
-pwd
 mkdir BUILDROOT
 cd BUILDROOT
 mkdir -p ${package_name}-1.x86_64


### PR DESCRIPTION
In Requires if we provide space b/w foglamp and foglamp_version text, then below error happens

```
Building the new package...
error: line 16: Dependency tokens must begin with alpha-numeric, '_' or '/': Requires:      foglamp >=1.5
```